### PR TITLE
PR to address #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,8 +152,6 @@ function focusUid({dispatch}, uid) {
 // Listens for cli commands and sessions
 exports.middleware = store => next => action => {
   const {type, data} = action
-  const {sessions} = store.getState()
-  const {activeUid} = sessions
 
   // Check for hyperlayout config
   if (type === 'SESSION_ADD_DATA') {

--- a/index.js
+++ b/index.js
@@ -165,11 +165,11 @@ exports.middleware = store => next => action => {
     }
   }
 
-  // Check for sessions
-  if (type === 'SESSION_SET_XTERM_TITLE' && hyperlayout) {
+ // Check for sessions
+  if (type === 'SESSION_ADD' && hyperlayout) {
     // Check if it's a new session
-    if (!hyperlayout.knownUids.includes(activeUid)) {
-      hyperlayout.knownUids.push(activeUid)
+    if (!hyperlayout.knownUids.includes(action.uid)) {
+      hyperlayout.knownUids.push(action.uid)
       setTimeout(() => {
         hyperlayout.work()
       }, 0)


### PR DESCRIPTION
This PR is in reference to issue #15. Switched from SESSION_SET_XTERM_TITLE(which was never occurring on my installation - Mac OSX) to SESSION_ADD to grab session uids. This seems to clear up my issues, but it should be tested on other environments as well.