### PR TITLE
Fixing bug #33

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ exports.middleware = store => next => action => {
   if (type === 'SESSION_ADD_DATA') {
     const testedData = /^\[hyperlayout config]:(.*)/.exec(data)
     if (testedData && testedData[1]) {
-      const config = JSON.parse(testedData[1])
+      const config = JSON.parse(testedData[1].substring(0, testedData[1].lastIndexOf('}') + 1))
       hyperlayout = new Hyperlayout(config, store)
       return
     }


### PR DESCRIPTION
Applying fix from @peternycander for issue #33 as per https://github.com/timolins/hyperlayout/issues/33#issuecomment-387126310

I have tested with latest hyper 2.1.1 on Windows 10.

@timolins the plugin is not usable without this fix on Window 10. Please release.