### PR TITLE
Fix windows

### DIFF
--- a/bin/hyperlayout
+++ b/bin/hyperlayout
@@ -111,7 +111,7 @@ function start() {
     return
   }
 
-  console.log('[hyperlayout config]:' + JSON.stringify(data))
+  console.log('[hyperlayout config]:' + JSON.stringify(data) + '[endconfig]')
 }
 
 start()

--- a/bin/hyperlayout
+++ b/bin/hyperlayout
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const {readFileSync} = require('fs')
+const {readFileSync, existsSync} = require('fs')
 const {homedir} = require('os')
 const {resolve} = require('path')
 const vm = require('vm')
@@ -13,14 +13,15 @@ const readJson = (dir, file) => JSON.parse(readFileSync(`${dir}/${file}`, 'utf8'
 // Check if user has hyperlayout plugin installed
 const isPluginInstalled = () => {
   const path = resolve(homedir(), '.hyper.js')
+  const pathWin = resolve(`${homedir()}/AppData/Roaming/Hyper`, '.hyper.js')
   try {
-    const hyperConfig = readFileSync(path, 'utf8')
+    const hyperConfig = existsSync(path, 'utf8') ? readFileSync(path, 'utf8') : readFileSync(pathWin, 'utf8')
     const script = new vm.Script(hyperConfig)
     const module = {}
     script.runInNewContext({module})
     const {plugins, localPlugins} = module.exports
     const pluginArray = plugins.concat(localPlugins)
-    return pluginArray.includes('hyperlayout')
+    return pluginArray.join(',').includes('hyperlayout')
   } catch (err) {
     debug(err)
     return false

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ exports.middleware = store => next => action => {
 
   // Check for hyperlayout config
   if (type === 'SESSION_ADD_DATA') {
-    const testedData = /^\[hyperlayout config]:(.*)/.exec(data)
+    const testedData = /^\[hyperlayout config]:(.*)\[endconfig\]/.exec(data.replace(/[\n\r]/gm, ''))
     if (testedData && testedData[1]) {
       const config = JSON.parse(testedData[1])
       hyperlayout = new Hyperlayout(config, store)


### PR DESCRIPTION
This PR aims to fix the following:
- error loading hyper.js config on windows 10
- error loading long hyperlayouts on windows 10 (newlines breaking json)

There have been other PRs on this, but I believe this is an easier solution, and it includes a fix for the config load issues.

I have only tested this on my own machine running windows 10, can't promise it'll work on other windows.